### PR TITLE
Shell factory gunpowder input fix

### DIFF
--- a/mods/[Gameplay] Military Attention/data/hier0nimus/military-buildings/assets.include.xml
+++ b/mods/[Gameplay] Military Attention/data/hier0nimus/military-buildings/assets.include.xml
@@ -4710,7 +4710,7 @@
         <FactoryBase>
           <FactoryInputs>
             <Item>
-              <Product>1742100291</Product>              <!-- Gunpowder -->
+              <Product>1742100293</Product>              <!-- Gunpowder -->
               <Amount>1</Amount>
               <StorageAmount>10</StorageAmount>
             </Item>


### PR DESCRIPTION
Small correction at the gunpowder input to the shell factory. This was not the correct product.

![image](https://github.com/Hier0nimus/anno-mods-hier0nimus/assets/67518676/0e4583e4-3ff7-41b6-8466-4dc275906472)

Simple edition of the product id to achieve the right behavior:

![image](https://github.com/Hier0nimus/anno-mods-hier0nimus/assets/67518676/bb3bed95-1828-4d99-a4c3-122485309aeb)
